### PR TITLE
README: Fix installation instruction.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ nincat random
 
 From your terminal, you can clone in your preferred folder:
 ```zsh
-git clone 'https://github.com/BeyondMagic/nincat.git'
+git clone 'https://github.com/ninecath/nincat'
 cd nincat
 make
 nincat random


### PR DESCRIPTION
To install `nincat` using Git, clone this repository, i.e.,
`ninecath/nincat` not any other private repository.

Earlier, the instruction to install `nincat` using Git, instructed to clone https://github.com/BeyondMagic/nincat.git which seems to be a private repository.

I am not sure whether that was put intentionally or it was a mistake.